### PR TITLE
added blacklisting of test cases

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -39,6 +39,7 @@ my $builder = Module::Build->new(
         'XML::Simple'       => 0,
         'YAML'              => 0,
         'YAML::Syck'        => 0,
+        'boolean'           => 0,
         'version'           => 0,
     },
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -51,6 +51,7 @@ t/RPM/Grill/20multilib.t
 t/RPM/Grill/30aggregate_gripes.t
 t/RPM/Grill/40codes.t
 t/RPM/Grill/50as_xml.t
+t/RPM/Grill/60blacklisting.t
 t/RPM/Grill/Plugin/10order.t
 t/RPM/Grill/Plugin/20docs.t
 t/RPM/Grill/Plugin/90real-world.t

--- a/bin/rpmgrill
+++ b/bin/rpmgrill
@@ -57,6 +57,16 @@ OPTIONS:
 
   --list-plugins     list available plugins
   --disable=[LIST]   disable one or more plugins, e.g.: --disable=virus,buildlog
+  --blacklist-config=FILE
+      Blacklisted tests will not be reported by $ME. Blacklist
+      configuration FILE is in YAML format:
+      ---
+      blacklist:
+        Plugin1: test1, test2
+        Plugin2: test3
+        ...
+      and tells $ME that it should not report fails for specified tests
+      within certain plugins.
 
   -v, --verbose  show verbose progress indicators
   -n, --dry-run  make no actual changes
@@ -104,6 +114,7 @@ sub man {
 our $debug   = 0;
 our $force   = 0;
 our $verbose = 0;
+our $blacklist = '';
 our $NOT     = '';              # print "blahing the blah$NOT\n" if $debug
 our $list_plugins;              # list plugins, and quit
 our @disable_plugin;            # plugins to disable
@@ -117,6 +128,7 @@ sub handle_opts {
 
         'list-plugins' => \$list_plugins,
         'disable=s'  => \@disable_plugin,
+        'blacklist-config=s' => \$blacklist,
 
         help         => \&usage,
         man          => \&man,
@@ -174,6 +186,9 @@ sub main {
     -d "$base_dir/src"
         or die "$ME: Base directory $base_dir does not have a 'src' subdir\n";
 
+    # Load blacklisted test cases.
+    RPM::Grill::load_blacklist($blacklist);
+
     # Find all plugins. Do this before cd'ing, in case we have relative
     # paths in our @INC.
     my @all_plugins = RPM::Grill->plugins();
@@ -229,7 +244,7 @@ rpmgrill - static analysis of koji builds
 
 =head1	SYNOPSIS
 
-rpmgrill [--disable=LIST] [--verbose] BASEDIR
+rpmgrill [--disable=LIST] [--verbose] [--blacklist-config=FILE] BASEDIR
 
 rpmgrill  B<--help>  |  B<--version> | B<--man>
 
@@ -266,6 +281,19 @@ but not spend 10 minutes in the VirusCheck plugin.
 =item B<--verbose>
 
 Show progress messages.
+
+=item B<--blacklist-config=FILE>
+
+Blacklisted tests will not be reported by rpmgrill. Blacklist configuration
+FILE is in YAML format:
+
+blacklist:
+  Plugin1: test1, test2
+  Plugin2: test3
+  ...
+
+and tells rpmgrill that it should not report fails for specified tests within
+certain plugins.
 
 =item B<--help>
 

--- a/t/RPM/Grill/60blacklisting.t
+++ b/t/RPM/Grill/60blacklisting.t
@@ -1,0 +1,124 @@
+# -*- perl -*-
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Differences;
+use File::Temp qw(tempdir);
+
+my $bfile = "blacklist.test";
+my $tempdir = tempdir("t-RPM-Grill-RPM.XXXXXX", CLEANUP => 1);
+
+use_ok 'RPM::Grill' or exit;
+
+###############################################################################
+package RPM::Grill::Plugin::Foo;
+
+sub load_blacklist {
+    RPM::Grill::load_blacklist(@_);
+}
+
+sub is_blacklisted {
+    return RPM::Grill::is_blacklisted(@_);
+}
+
+sub gripe_signature {
+    return RPM::Grill::gripe_signature(@_);
+}
+
+sub nvr { return ("name", "ver", "rel") }
+
+sub plugins {
+    my $self = shift;
+
+    my $plugins = <<END_PLUGINS;
+1    BuildLog      completed
+2    DesktopLint   completed
+5    ElfChecks     completed
+10   Multilib      completed
+END_PLUGINS
+    my @plugins;
+
+    my %gripes = (
+        BuildLog    => {code => 'MacroExpansion', diag => 'diag1'},
+        DesktopLint => {code => 'DesktopFileValidation', diag => 'diag2'},
+        ElfChecks   => {code => 'DaemonPartialRELRO', diag => 'diag3'},
+        Multilib    => {code => 'MultilibMismatch', diag => 'diag4'},
+    );
+
+    load_blacklist("$tempdir/$bfile");
+
+    for my $line (split "\n", $plugins) {
+        my ($order, $name, $status) = split ' ', $line;
+
+        eval "push \@RPM::Grill::Plugin::${name}::ISA, 'RPM::Grill::Plugin'";
+        die "Foo: $@" if $@;
+
+        push @plugins, bless {
+            name => $name,
+            order => $order,
+            status => $status,
+        }, "RPM::Grill::Plugin::$name";
+
+        $self->{results}{$name} = { status => $status, run_time => 10 };
+        if (my $g = $gripes{$name}) {
+            my $sig = gripe_signature(\%$g);
+            if (! is_blacklisted($name, $sig)) {
+                $self->{gripes}{$name} = $g;
+            }
+        }
+    }
+
+    return @plugins;
+}
+
+package RPM::Grill::Plugin;
+sub order { return $_[0]->{order} };
+use overload '""' => sub { return ref($_[0]) };
+
+package main;
+###############################################################################
+
+open my $fileh, '>', "$tempdir/$bfile" or die "Unable to create new file: $!";
+print $fileh <<EOF;
+---
+blacklist:
+  BuildLog: MacroExpansion, MiscBuildError
+  Multilib: MultilibMismatch, DepGenDisabled
+EOF
+close("$tempdir/$bfile");
+
+
+my $m = bless {}, 'RPM::Grill::Plugin::Foo';
+my $actual_yaml = RPM::Grill::results_as_yaml($m);
+
+# remove timestamp and rpmgrill version from final output
+$actual_yaml =~ s/^.*timestamp.*\n//gm;
+$actual_yaml =~ s/^.*version.*\n//m;
+
+my $expected_yaml = do { local $/ = undef; <DATA>; };
+
+eq_or_diff $actual_yaml, $expected_yaml, "blacklist-config option";
+
+unlink "$tempdir/$bfile";
+done_testing;
+
+
+__DATA__
+---
+results:
+  tool: 60blacklisting.t
+package:
+  name: name
+  version: ver
+  release: rel
+tests:
+  - '001 BuildLog    : completed (10s)'
+  - '002 DesktopLint : completed (10s)':
+      code: DesktopFileValidation
+      diag: diag2
+  - '005 ElfChecks   : completed (10s)':
+      code: DaemonPartialRELRO
+      diag: diag3
+  - '010 Multilib    : completed (10s)'


### PR DESCRIPTION
Added "--blacklist-config=FILE" option which provides a blacklist file
to the rpmgrill. Blacklisted tests will not be reported by rpmgrill.
Blacklist configuration FILE is in YAML format:

blacklist:
  Plugin1: test1, test2
  Plugin2: test3
  ...

and tells rpmgrill that it should not report fails for specified tests
within certain plugins.

Blacklisting is used for disabling individual tests within certain
plugins not the whole plugins. To disable the whole plugin use
"--disable" option instead.
