### PR TITLE
Run rpmgrill in Travis via Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+services:
+  - docker
+
+script:
+  - cd dev-tools/docker
+  - sudo docker-compose build ci
+  - sudo docker-compose run ci /usr/bin/prove -lrcf t

--- a/dev-tools/docker/README.asciidoc
+++ b/dev-tools/docker/README.asciidoc
@@ -15,9 +15,8 @@ devenv::
     can install new packages without exiting the container.
 
 ci::
-    `ci` image is based on `Fedora 20` and contains all dependencies needed to
-    run `RpmGrill` tests. This image closely replicates the container used in
-    https://209.132.179.19/[RpmGrill Jenkins].
+    `ci` image is based on `Fedora 24` and contains all dependencies needed to
+    run `RpmGrill` tests. This image is used in our Travis CI environment.
 
 Building Images
 ~~~~~~~~~~~~~~~~

--- a/dev-tools/docker/ci/f24/Dockerfile
+++ b/dev-tools/docker/ci/f24/Dockerfile
@@ -1,0 +1,27 @@
+FROM fedora:24
+MAINTAINER rpmdiff-maint@redhat.com
+
+### setup installs /usr/share/doc/setup-*/uidgid  ###
+### need by rpmgrill so ensure docs are installed ###
+RUN dnf reinstall -y setup && \
+    dnf -y clean all
+
+### test dependencies ###
+RUN dnf install -y \
+        tar bzip2 desktop-file-utils rpm-build redhat-rpm-config \
+        clamav clamav-data elfutils koji git libxslt \
+        clamav clamav-data elfutils koji git libxslt perl-Test-Harness \
+        perl-Test-Perl-Critic perl-HTML-Parser perl-XML-Simple perl-JSON-XS \
+        perl-YAML perl-File-LibMagic perl-Test-Differences  perl-IPC-Run \
+        perl-Sort-Versions perl-Digest-SHA1 perl-File-Slurp \
+        perl-Test-LongString perl-Time-ParseDate perl-YAML-Syck \
+        perl-Time-Piece  perl-CGI perl-Test-Deep perl-Module-Build \
+        perl-Net-DNS perl-Pod-POM perl-Test-MockObject perl-XMLRPC-Lite \
+        perl-SOAP-Lite perl-Devel-Cover perl-Test-Exception \
+        perl-File-Fetch perl-List-AllUtils perl-Test-MockModule \
+        perl-open perl-boolean && \
+    dnf -y clean all
+
+
+WORKDIR /code
+CMD  bash

--- a/dev-tools/docker/docker-compose.yml
+++ b/dev-tools/docker/docker-compose.yml
@@ -2,7 +2,7 @@
 f21: &devenv
   build: devenv/f21
   privileged: true
-  user: 1000
+  user: "1000"
   volumes:
     - &code  ../../:/code
     - &projectdir ../../../:/project
@@ -17,7 +17,7 @@ centos7:
 
 ### minimal env to test rpmgrill ###
 ci:
-  build: ci/f20
+  build: ci/f24
   privileged: true
   volumes:
     - *code


### PR DESCRIPTION
This adds a minimal travis configuration using docker to run rpmgrill
tests in a Fedora 24 environment.

The environment runs as privileged in order to allow tests to write temporary files into the working directory.