### PR TITLE
Include armv7 and aarch64 in arches

### DIFF
--- a/lib/RPM/Grill.pm
+++ b/lib/RPM/Grill.pm
@@ -66,6 +66,7 @@ our $Arch_Map = <<'END_ARCH_MAP';
 i386 i586 i686 athlon  | x86_64 ia64
 ppc                    | ppc64
 s390                   | s390x
+armv7hl                | aarch64
 END_ARCH_MAP
 
 # 2013-01-18 these are special Windows "architectures". They are not

--- a/t/RPM/Grill/10arch-order.t
+++ b/t/RPM/Grill/10arch-order.t
@@ -18,6 +18,7 @@ my @tests = (
     [ qw( src i686 x86_64 ppc ppc64 s390 s390x ) ],
     [ qw( src             ppc ppc64 s390 s390x ) ],
     [ qw(                 ppc ppc64 s390 s390x ) ],
+    [ qw(     aarch64 armv7hl i686  x86_64     ) ],
 );
 plan tests => 1 + 2 * @tests;
 


### PR DESCRIPTION
The rpmgrill tool currently has no concept of Arm architectures which
leads to a warning during output. This adds 32bit and 64bit
architectures to it's architectures list.

Bug: 1199960