### PR TITLE
rpmgrill-fetch-build: use https in default Koji urls

### DIFF
--- a/bin/rpmgrill-fetch-build
+++ b/bin/rpmgrill-fetch-build
@@ -96,8 +96,8 @@ for my $line (split "\n", $Metadata_Files) {
 # These arches don't need a build log.
 our %Doesnt_Need_Build_Log = map { $_ => 1 } ('noarch');
 
-our $DEFAULT_SERVER_URL = 'http://koji.fedoraproject.org/kojihub';
-our $DEFAULT_TOP_URL = 'http://kojipkgs.fedoraproject.org';
+our $DEFAULT_SERVER_URL = 'https://koji.fedoraproject.org/kojihub';
+our $DEFAULT_TOP_URL = 'https://kojipkgs.fedoraproject.org';
 
 # END   user-customizable section
 ###############################################################################


### PR DESCRIPTION
Koji returns 405's and redirects when querying on plain http,
this causes fetch-build to fail. Simply switching to use https
solves the issue.

See:
rpmgrill-fetch-build carbon-c-relay-2.5-1.fc25 /tmp/pkg
405 Method Not Allowed at /usr/bin/rpmgrill-fetch-build line 345.
<< download failed >>