### PR TITLE
rpmgrill-fetch-build: fix sort

### DIFF
--- a/bin/rpmgrill-fetch-build
+++ b/bin/rpmgrill-fetch-build
@@ -282,7 +282,7 @@ sub package_name {
 sub arches {
     my ($self, $rpms) = @_;
 
-    return sort uniq map { $_->{'arch'} } @$rpms;
+    return uniq sort map { $_->{'arch'} } @$rpms;
 }
 
 

--- a/t/10fetch-build.t
+++ b/t/10fetch-build.t
@@ -39,6 +39,8 @@ subtest 'Koji Build' => sub {
     my $rpms = [
         { 'arch' => 'src', },
         { 'arch' => 'i386', },
+        { 'arch' => 'src', },
+        { 'arch' => 'i386', },
     ];
     my @got = $build->arches($rpms);
     eq_or_diff (\@got, [qw( i386 src )], 'returns correct arches');


### PR DESCRIPTION
`sort uniq` uses uniq as a comparator to do the sort and results in
dupplicate values. Improved the test to catch this.

Fixed the test error:
"return" statement followed by "sort" at line 285, column 5. Behavior
is undefined if called in scalar context.  (Severity: 5)"