### PR TITLE
Use Fedora copr to automatically create builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ before_script:
 
 script:
   - make dockertest
-  - make rpmtest

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ SPECFILE = $(NAME).spec
 
 VERSION = $(shell git describe --abbrev=0)
 RELEASE = $(shell rpm -q --specfile $(SPECFILE) --queryformat '%{RELEASE}')
-BUILDDIR = /tmp/rpmbuild
 
 # Magic tag thingy for building
 DIST = fc24
@@ -19,25 +18,6 @@ $(VERSION).tar.gz:
 
 $(NAME)-$(VERSION)-$(RELEASE).src.rpm: $(VERSION).tar.gz
 	rpmbuild -bs --nodeps --define "_sourcedir ." --define "_srcrpmdir ." --define "dist .$(DIST)" $(SPECFILE)
-
-.PHONY: rpmbuild rpmtest
-rpmbuild: $(VERSION).tar.gz
-	@rm -rf $(BUILDDIR)
-	docker pull mmornati/mock-rpmbuilder:v1.0
-	mkdir $(BUILDDIR)
-	mv $< $(BUILDDIR)
-	cp rpmgrill.spec $(BUILDDIR)
-	chown -R 1000:1000 $(BUILDDIR)
-	docker run --cap-add=SYS_ADMIN -it\
-		-e MOCK_CONFIG=fedora-24-x86_64\
-		-e SOURCES=$< \
-		-e SPEC_FILE=rpmgrill.spec\
-		-v $(BUILDDIR):/rpmbuild\
-		mmornati/mock-rpmbuilder:v1.0
-
-# poor mans check if the rpm build was successful
-rpmtest: rpmbuild
-	find $(BUILDDIR)/output -name 'rpmgrill-*.noarch.rpm' | egrep '.*'
 
 .PHONY: dockertest
 dockertest: dev-tools/docker/docker-compose.yml

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -110,3 +110,9 @@ To add, extend, or fix individual rpmgrill tests see README.devel-tests
 
 For deeper development, such as ongoing maintenance or infrastructure
 development (or perhaps infrastructure bug fixes), see README.devel-deep
+
+Nightly Builds
+--------------
+
+Easy installable packages are available via
+https://copr.fedorainfracloud.org/coprs/romanofski/rpmgrill/[Fedora copr].


### PR DESCRIPTION
This patch removes a clutch to build RPMs for just testing purposes in
Travis to know if the build is potentially broken. The configuration
used was only Fedora 24 and failed.

Rethinking the whole situation, this patch removes the clutch to only
leave executing the tests in travis, but puts the RPM building in the
responsibility of Fedora copr.