### PR TITLE
Adapt to Perl 5.26

### DIFF
--- a/t/RPM/Grill/RPM/Files/20eu-readelf.t
+++ b/t/RPM/Grill/RPM/Files/20eu-readelf.t
@@ -39,7 +39,7 @@ BEGIN {
         my $t = { name => $d };
 
         #
-        $t->{expect} = do "$test_subdir/$d/expect";
+        $t->{expect} = do "./$test_subdir/$d/expect";
         die "Internal error: eval $test_subdir/$d/expect: $@" if $@;
 
         push @tests, $t;


### PR DESCRIPTION
Perl 5.26.0 removed "." from @INC, thus
t/RPM/Grill/RPM/Files/20eu-readelf.t test fails becaue it cannot load
"expect" files via "do".

This patch fixes this test. There are maybe other places to fix.