### PR TITLE
Do not require config files to have a man page

### DIFF
--- a/lib/RPM/Grill/Plugin/ManPages.pm
+++ b/lib/RPM/Grill/Plugin/ManPages.pm
@@ -239,12 +239,9 @@ sub _file_needs_manpage {
     #   * regular files (i.e. not symlinks or directories) that are:
     return 0 if ! $bin->is_reg;
 
-    #      * executable and in an important directory, or
+    #      * executable and in an important directory
     return 1 if $bin->numeric_mode & 0x100
              && $bin->path =~ m{^($Important_Bin_Directories)/};
-
-    #      * marked (in rpm) as config files (bz647369)
-    return 1 if $bin->is_config;
 
     # Not one of the above. File does not need a man page.
     return;


### PR DESCRIPTION
Currently, the man page plugin expects all regular files marked
as configuration to have man pages, and records a failure if
they don't. This is commented with a reference to
https://bugzilla.redhat.com/show_bug.cgi?id=647369 , which is a
(unfortunately private) bug against an internal RH tool from
which I believe rpmgrill was initially forked. It basically
requests that tool should expect all files under /etc marked
as configuration files to have man pages, but with no very clear
justification.

That check was initially added to the tool and went live for a
while, but after several complaints from packagers, it was
removed again on the basis there's no Fedora or RHEL guideline
that requires this, and there are certainly cases where a file
is reasonably a config file in /etc but also reasonably does not
require a man page.

It looks like rpmgrill was forked between the check being added
and it being removed, but when it was removed from the original
tool, it was never removed from rpmgrill. So, we should just
remove it from rpmgrill as well.

Signed-off-by: Adam Williamson <awilliam@redhat.com>