### PR TITLE
Resync spec file with Fedora package repo, fix %check

### DIFF
--- a/rpmgrill.spec
+++ b/rpmgrill.spec
@@ -1,6 +1,6 @@
 Name:           rpmgrill
 Version:        0.32
-Release:        2%{?dist}
+Release:        5%{?dist}
 Summary:        A utility for catching problems in koji builds
 Group:          Development/Tools
 License:        Artistic 2.0
@@ -11,6 +11,7 @@ Requires:       perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $versi
 Requires:       perl(Module::Pluggable)
 
 # For the antivirus plugin
+Requires: clamav
 Requires: data(clamav)
 Suggests: clamav-data
 
@@ -85,6 +86,10 @@ multilib incompatibilities.
 %install
 ./Build pure_install --destdir %{buildroot}
 
+find %{buildroot} -type f -name .packlist -exec rm -f {} \;
+
+%{_fixperms} %{buildroot}/*
+
 %check
 %if 0%{?fedora} >= 24 || 0%{?rhel} >= 8
 prove -lrcf t
@@ -93,10 +98,6 @@ prove -lrcf t
 # platform dependent
 prove -lcf t
 %endif
-
-find %{buildroot} -type f -name .packlist -exec rm -f {} \;
-
-%{_fixperms} %{buildroot}/*
 
 %files
 %doc README.asciidoc LICENSE AUTHORS


### PR DESCRIPTION
The spec files in this repo and the downstream Fedora package
repo are meant, I think, to be in sync, but they've got a bit
out of sync over time. Only this repo has the %check section, so
we need to add that downstream; there also some changes in
a135cbf that were never sent downstream, so we'll need to do
those too.

On the other hand, c4ced6b mistakenly removed the dependency on
clamav itself; I corrected that in the downstream spec, so we
need to sync that change here.

I also noticed that %check appears to have been added in the
wrong place, slightly - it's right in the middle of %install,
not after it. The `packlist` and `fixperms` lines are supposed
to be part of %install, not %check, but the way %check was added
they wound up in %check. So, this fixes that too.

This version should hopefully be the best of all worlds!

Signed-off-by: Adam Williamson <awilliam@redhat.com>