### PR TITLE
Fixes build failure for EPEL7

### DIFF
--- a/rpmgrill.spec
+++ b/rpmgrill.spec
@@ -13,7 +13,6 @@ Requires:       perl(Module::Pluggable)
 # For the antivirus plugin
 Requires: clamav
 Requires: data(clamav)
-Suggests: clamav-data
 
 # For checking desktop/icon files using /usr/bin/desktop-file-validate
 Requires: /usr/bin/desktop-file-validate


### PR DESCRIPTION
Builds for EPEL-7 are currently failing with:

    BUILDSTDERR: error: line 16: Unknown tag: Suggests: clamav-data

This fix introduces a test and fails back to the suggestion from Bug
1520003.