### PR TITLE
Allow icons in top-level base directories

### DIFF
--- a/lib/RPM/Grill/Plugin/DesktopLint.pm
+++ b/lib/RPM/Grill/Plugin/DesktopLint.pm
@@ -337,7 +337,7 @@ sub _check_icon {
         $icon_re = qr{^\Q$icon\E$};
     }
     else {
-        $icon_re = qr{^/usr/share/(icons|pixmaps)/.*\Q/$icon\E\.(png|xpm|svg)$};
+        $icon_re = qr{^/usr/share/(?:icons|pixmaps)/(?:.*/)?\Q$icon\E\.(?:png|xpm|svg)$};
     }
 
     # Look through all packages on this arch.  (And, if we're a binary arch

--- a/t/RPM/Grill/Plugin/DesktopLint/10basic.t
+++ b/t/RPM/Grill/Plugin/DesktopLint/10basic.t
@@ -407,6 +407,22 @@ Type=Application
 >> -rwxr-xr-x  root  root 0   /noarch/mypkg/usr/bin/foo
 >> -rwxr-xr-x  root  root 0   /noarch/mypkg-icons/usr/share/icons/myicon.png
 
+-------icon-ok-(without-theme)------------------------------------------------
+# Icons specified as a base file name without a path can be located in
+# a top-level base directory out of any theme (see LookupFallbackIcon in Theme
+# specification), bug #1539633.
+>> -rw-r--r--  root  root 0 /i386/mypkg/usr/share/applications/foo.desktop
+[Desktop Entry]
+Name=Foo
+Comment=Bar
+Exec=foo
+Icon=myicon
+Terminal=false
+Type=Application
+
+>> -rwxr-xr-x  root  root 0   /i386/mypkg/usr/bin/foo
+>> -rwxr-xr-x  root  root 0   /i386/mypkg/usr/share/icons/myicon.png
+
 -------icon-badmode-------------------------------------------------
 # icon is not world-readable
 >> -rw-r--r--  root  root 0 /noarch/mypkg/usr/share/applications/foo.desktop


### PR DESCRIPTION
Icons specified as a base file name without a path can be located in
a top-level base directory out of any theme (see LookupFallbackIcon in Theme
specification), bug #1539633.

Perl syntax notice: This patch uses non-possive groups in the regular
expression to increase performance.